### PR TITLE
fix undefined search string

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -12,7 +12,7 @@ module.exports = {
           // side effects
           return;
         }
-        if (!s.length) {
+        if (!s && !s.length) {
           self.set('elasticsearch', false);
           return;
         }


### PR DESCRIPTION
In case that you have defined a cursor with filter `.search(string)` and string is undefined, the server process crash.